### PR TITLE
Fix empty meta.filter bug which results in empty page list

### DIFF
--- a/PicoTags.php
+++ b/PicoTags.php
@@ -83,9 +83,11 @@ class PicoTags extends AbstractPicoPlugin
      */
     private static function parseTags($tags)
     {
-        if (is_string($tags) && (strpos($tags, ',') !== false)) {
-            $tags = explode(',', $tags);
+        if (!is_string($tags) || mb_strlen($tags) <= 0) {
+            return array();
         }
+
+        $tags = explode(',', $tags);
 
         return is_array($tags) ? array_map('trim', $tags) : array();
     }

--- a/PicoTags.php
+++ b/PicoTags.php
@@ -83,7 +83,7 @@ class PicoTags extends AbstractPicoPlugin
      */
     private static function parseTags($tags)
     {
-        if (is_string($tags)) {
+        if (is_string($tags) && (strpos($tags, ',') !== false)) {
             $tags = explode(',', $tags);
         }
 


### PR DESCRIPTION
For an empty meta.filter, `private static function parseTags($tags)` returns: `array(1) { [0]=> string(0) "" }`

This result is passed into `empty()` inside `public function onPagesLoaded(&$pages, &$currentPage, &$previousPage, &$nextPage)` which returns false of, course.

I added an additional check to `parseTags($tags)`.