### PR TITLE
Tags all

### DIFF
--- a/PicoTags.php
+++ b/PicoTags.php
@@ -89,14 +89,11 @@ class PicoTags extends AbstractPicoPlugin
     }
 
     /**
-     * Register Twig's get_all_tags.
-     * I don't know if it has to be in this method; just copying from http-params ;)
-     *
-     * @see DummyPlugin::onPageRendering()
+     * Register get_all_tags in Twig.
      */
-    public function onPageRendering(Twig_Environment &$twig, array &$twigVariables, &$templateName)
+    public function onTwigRegistration()
     {
-        $twig->addFunction(new Twig_SimpleFunction('get_all_tags', array($this, 'getAllTags')));
+        $this->getPico()->getTwig()->addFunction(new Twig_SimpleFunction('get_all_tags', array($this, 'getAllTags')));
     }
 
     public function getAllTags() {

--- a/PicoTags.php
+++ b/PicoTags.php
@@ -96,7 +96,7 @@ class PicoTags extends AbstractPicoPlugin
      */
     public function onPageRendering(Twig_Environment &$twig, array &$twigVariables, &$templateName)
     {
-        $twig->addFunction(new Twig_SimpleFunction('get_all_tags', array($this, 'getTags')));
+        $twig->addFunction(new Twig_SimpleFunction('get_all_tags', array($this, 'getAllTags')));
     }
 
     public function getAllTags() {

--- a/PicoTags.php
+++ b/PicoTags.php
@@ -24,6 +24,11 @@ class PicoTags extends AbstractPicoPlugin
 {
 
     /**
+     * All tags used in all pages.
+     */
+    protected $allTags = [];
+
+    /**
      * Register the "Tags" and "Filter" meta header fields.
      *
      * @see    Pico::getMetaHeaders()
@@ -65,6 +70,14 @@ class PicoTags extends AbstractPicoPlugin
      */
     public function onPagesLoaded(&$pages, &$currentPage, &$previousPage, &$nextPage)
     {
+        foreach ($pages as $page) {
+            $tags = PicoTags::parseTags($page['meta']['tags']);
+            if ($page && !empty($tags)) {
+                $this->allTags = array_merge($this->allTags, $tags);
+            }
+            $this->allTags = array_unique($this->allTags);
+        }
+
         if ($currentPage && !empty($currentPage['meta']['filter'])) {
             $tagsToShow = $currentPage['meta']['filter'];
 
@@ -75,6 +88,21 @@ class PicoTags extends AbstractPicoPlugin
         }
     }
 
+    /**
+     * Register Twig's tags_all.
+     * I don't know if it has to be in this method; just copying from http-params ;)
+     *
+     * @see DummyPlugin::onPageRendering()
+     */
+    public function onPageRendering(Twig_Environment &$twig, array &$twigVariables, &$templateName)
+    {
+        $twig->addFunction(new Twig_SimpleFunction('tags_all', array($this, 'getTags')));
+    }
+
+    public function getTags() {
+        return $this->allTags;
+    }
+    
     /**
      * Get array of tags from metadata string.
      *

--- a/PicoTags.php
+++ b/PicoTags.php
@@ -89,17 +89,17 @@ class PicoTags extends AbstractPicoPlugin
     }
 
     /**
-     * Register Twig's tags_all.
+     * Register Twig's get_all_tags.
      * I don't know if it has to be in this method; just copying from http-params ;)
      *
      * @see DummyPlugin::onPageRendering()
      */
     public function onPageRendering(Twig_Environment &$twig, array &$twigVariables, &$templateName)
     {
-        $twig->addFunction(new Twig_SimpleFunction('tags_all', array($this, 'getTags')));
+        $twig->addFunction(new Twig_SimpleFunction('get_all_tags', array($this, 'getTags')));
     }
 
-    public function getTags() {
+    public function getAllTags() {
         return $this->allTags;
     }
     

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can add a side-bar listing documents with the same tags by including somethi
 ```twig
 <aside> 
 {% for tag in meta.tags %}
-    <h3>Mere under: <a href="{{ base_url }}/tags/?tag={{ tag }}">{{ tag }}</a></h3>
+    <h3>More pages tagged: <a href="{{ base_url }}/tags/?tag={{ tag }}">{{ tag }}</a></h3>
     <ul>
     {% for page in pages if page.title and page.meta.tags %}
         {% if tag in page.meta.tags and not (page.id ends with 'index') and page.id != current_page.id %}

--- a/README.md
+++ b/README.md
@@ -55,3 +55,51 @@ done in the template file, e.g.:
     </article>
 {% endfor %}
 ```
+
+To create a dedicated tags page for either showing a list of available tags or a list of
+documents with a specific tag, use the builtin `tags_all()` function:
+
+Create a document `tags.md` in the root of the site:
+
+```
+---
+Title: Tags
+Template: tags
+---
+
+Content can go here
+
+```
+
+The tags template can look like this:
+
+```
+{% extends "index.twig" %}
+{% set tag = url_param('tag', 'string') %}
+{% set tags = tags_all() %}
+{% block content %}
+{{ parent() }}
+{% if tag %}
+    <ul>
+    {% for page in pages if page.title and tags and not (page.id ends with 'index') %}
+        {% set pageTags = page.meta.tags|split(',') %}
+        {% if tag in pageTags %}
+            <li><a href="{{ page.url }}">
+            {{ page.title }} - {{ page.meta.tags }}</a>
+            </li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+{% else %}
+    No tag given:
+    <ul>
+    {% for tag in tags %}
+        <li><a href="{{current_page.url}}/?tag={{ tag }}">{{ tag }}</li>
+    {% endfor %}
+    </ul>
+{% endif %}
+{% endblock content %}
+```
+
+If called like `https://www.example.com/tags/?tag=pancakes` it will return a list of documents
+with tag `pancakes`. If called without arguments, it will return a list of all available tags.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ done in the template file, e.g.:
 {% endfor %}
 ```
 
-You can add a sidebar listing documents with the same tags by including something like:
+### Listing related documents
+
+You can list documents with the same tags as the current page by including something like this in your template:
 
 ```twig
 <aside> 
@@ -75,11 +77,11 @@ You can add a sidebar listing documents with the same tags by including somethin
 </aside> 
 ```
 
-To create a dedicated tags page for either showing a list of available tags or a list of
-documents with a specific tag, use the builtin `get_all_tags()` function:
+### Listing all tags used on the site
 
-Create a document `tags.md` in the root of the site:
+The plugin also makes the function `get_all_tags()` available in your templates. This example uses it to create a dedicated tags page for either showing a list of available tags, or a list of documents with a specific tag:
 
+### In tags.md
 ```
 ---
 Title: Tags
@@ -90,12 +92,13 @@ Content can go here
 
 ```
 
-The tags template can look like this:
-
+### In themes/default/tags.html
 ```twig
 {% extends "index.twig" %}
+
 {% set tag = url_param('tag', 'string') %}
 {% set tags = get_all_tags() %}
+
 {% block content %}
 {{ parent() }}
 {% if tag %}
@@ -110,7 +113,6 @@ The tags template can look like this:
     {% endfor %}
     </ul>
 {% else %}
-    No tag given:
     <ul>
     {% for tag in tags %}
         <li><a href="{{current_page.url}}/?tag={{ tag }}">{{ tag }}</li>
@@ -120,5 +122,5 @@ The tags template can look like this:
 {% endblock content %}
 ```
 
-If called like `https://www.example.com/tags/?tag=pancakes` it will return a list of documents
-with tag `pancakes`. If called without arguments, it will return a list of all available tags.
+This would make e.g. `https://www.example.com/tags?tag=pancakes` show a list of documents
+with the tag `pancakes`, whereas `https://www.example.com/tags` would show a list of all available tags.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Copy the file `PicoTags.php` to the `plugins` subdirectory of your Pico installa
 
 ## Usage
 
+### Basic usage
+
 To assign tags to a page, specify the `Tags` header inside the meta header block at the top of your file, e.g.:
 
-### In blog/my-first-blog-post.md
+#### In blog/my-first-blog-post.md
 ```
 ---
 Title: My first blog post
@@ -31,7 +33,7 @@ Template: blog-post
 
 To only show pages with certain tags on another page, use the `Filter` header, e.g.:
 
-### In blog/index.md
+#### In blog/index.md
 ```
 ---
 Title: Blog
@@ -45,7 +47,7 @@ These are all my blog posts:
 Actually looping through the filtered list of pages (in the above case, pages tagged `blog`) to display them would be
 done in the template file, e.g.:
 
-### In themes/default/blog-list.html
+#### In themes/default/blog-list.html
 ```twig
 {{ content }}
 {% for page in pages if page.title %}
@@ -81,7 +83,7 @@ You can list documents with the same tags as the current page by including somet
 
 The plugin also makes the function `get_all_tags()` available in your templates. This example uses it to create a dedicated tags page for either showing a list of available tags, or a list of documents with a specific tag:
 
-### In tags.md
+#### In tags.md
 ```
 ---
 Title: Tags
@@ -92,7 +94,7 @@ Content can go here
 
 ```
 
-### In themes/default/tags.html
+#### In themes/default/tags.html
 ```twig
 {% extends "index.twig" %}
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The tags template can look like this:
 ```twig
 {% extends "index.twig" %}
 {% set tag = url_param('tag', 'string') %}
-{% set tags = tags_all() %}
+{% set tags = get_all_tags() %}
 {% block content %}
 {{ parent() }}
 {% if tag %}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ done in the template file, e.g.:
 
 You can add a side-bar listing documents with the same tags by including something like:
 
-```
+```twig
 <aside> 
 {% for tag in meta.tags %}
     <h3>Mere under: <a href="{{ base_url }}/tags/?tag={{ tag }}">{{ tag }}</a></h3>
@@ -92,7 +92,7 @@ Content can go here
 
 The tags template can look like this:
 
-```
+```twig
 {% extends "index.twig" %}
 {% set tag = url_param('tag', 'string') %}
 {% set tags = tags_all() %}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ done in the template file, e.g.:
 {% endfor %}
 ```
 
+You can add a side-bar listing documents with the same tags by including something like:
+
+```
+<aside> 
+{% for tag in meta.tags %}
+    <h3>Mere under: <a href="{{ base_url }}/tags/?tag={{ tag }}">{{ tag }}</a></h3>
+    <ul>
+    {% for page in pages if page.title and page.meta.tags %}
+        {% if tag in page.meta.tags and not (page.id ends with 'index') and page.id != current_page.id %}
+        <li>
+            <a href="{{ page.url }}">{{ page.title }}</a> - {{ page.description }}
+        </li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+{% endfor %}
+</aside> 
+```
+
 To create a dedicated tags page for either showing a list of available tags or a list of
 documents with a specific tag, use the builtin `tags_all()` function:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can add a sidebar listing documents with the same tags by including somethin
 ```
 
 To create a dedicated tags page for either showing a list of available tags or a list of
-documents with a specific tag, use the builtin `tags_all()` function:
+documents with a specific tag, use the builtin `get_all_tags()` function:
 
 Create a document `tags.md` in the root of the site:
 


### PR DESCRIPTION
Hejsa Pontus

I extended the plugin with a `tags_all()` function, which gives all tags used in the site. There's a small snippet in README.md showing how.

I hope you can use it :)

NOTE:
* It's my first Pico/Twig experiment.
* It doesn't use the Pico 2.x `pages()` function. I couldn't get it to work, so still using the `pages` var.
* It uses normal GET vars like `/tags?tag=pancakes`. I would like to be able to use something like `tags/pancakes` instead. My original idea was to use URL rewrite, but I can see you made something like it in Pico-Search? Couldn't quite grasp it, though.
